### PR TITLE
Add option to override/disable auto-scaling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Usage
 | --- | --- | --- | --- |
 | forceTransparent | boolean | Attempts to force backgrounds to be transparent, even if the CD+G title did not explicitly specify it. Experimental. | false
 | onBackgroundChange | function | Callback that will be invoked when the canvas background color changes. The RGBA color is passed as an array like `[r, g, b, a]` with alpha being 0 or 1. The reported alpha includes the effect of the `forceTransparent` option, if enabled. | undefined |
+| scale | number | If specified, force drawing graphics at this level of scale. If unspecified, scale will be the largest multiple of 300x216 that can fit in the given canvas. | undefined |
 
 Basic example:
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const PACKET_SIZE = 24
 *
 ************************************************/
 class CDGContext {
-  constructor (userCanvas, { forceTransparent = false } = {}) {
+  constructor (userCanvas, { forceTransparent = false, scale = null } = {}) {
     // visible canvas
     this.userCanvas = userCanvas
     this.userCanvasCtx = userCanvas.getContext('2d')
@@ -37,6 +37,7 @@ class CDGContext {
     this.ctx = this.canvas.getContext('2d')
     this.imageData = this.ctx.createImageData(this.WIDTH, this.HEIGHT)
     this.forceTransparent = !!forceTransparent
+    this.scale = scale;
 
     this.init()
   }
@@ -69,7 +70,7 @@ class CDGContext {
 
   renderFrame () {
     const [left, top, right, bottom] = [0, 0, this.WIDTH, this.HEIGHT]
-    const scale = Math.min(
+    const scale = this.scale || Math.min(
       Math.floor(this.userCanvas.clientWidth / this.WIDTH),
       Math.floor(this.userCanvas.clientHeight / this.HEIGHT),
     )


### PR DESCRIPTION
Thanks for this library!

I'm using it in a place where I'm letting the browser scale the `<canvas>`'s parent, so that the bitmap scales up smoothly to fill the viewport. The built-in auto-scaling was interfering with this, as the canvas's contents would jump between 1x, 2x, 3x scale as the viewport size changes.